### PR TITLE
Fix layout issue where infoContainerView did not adapt via its width

### DIFF
--- a/src/gui/InformationContainerView.fxml
+++ b/src/gui/InformationContainerView.fxml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.layout.*?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.FlowPane?>
 
-<FlowPane id="main" fx:id="myFlowPane" hgap="5.0" minWidth="1024.0" stylesheets="@informationContainer.css" vgap="5.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gui.InformationContainerViewController">
+<FlowPane id="main" fx:id="myFlowPane" hgap="5.0" stylesheets="@informationContainer.css" vgap="5.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gui.InformationContainerViewController">
    <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
    </padding>

--- a/src/gui/SessionController.java
+++ b/src/gui/SessionController.java
@@ -232,6 +232,10 @@ public class SessionController {
 		// go to default screen
 		infoViewController.showAdminAuctions(myManager.getAllAuctionsSorted(), myManager);
 		theController.showDatePicker(infoViewController, myManager);
+		
+//		ScrollPane scrollPane = theController.getMyScrollPane();
+//		scrollPane.setContent(infoViewController);
+//		infoViewController.prefWidthProperty().bind(scrollPane.widthProperty().subtract(20));
 	}
 	
 
@@ -316,7 +320,8 @@ public class SessionController {
 		
 		ScrollPane scrollPane = theUserViewController.getMyScrollPane();
 		scrollPane.setContent(informationContainerView);
-		informationContainerView.prefWidthProperty().bind(scrollPane.widthProperty().subtract(20));
+		informationContainerView.prefWidthProperty().bind(scrollPane.widthProperty().subtract(0));
+		informationContainerView.prefHeightProperty().bind(scrollPane.heightProperty().subtract(20));
 		informationContainerViewController = 
 				(InformationContainerViewController) informationContainerLoader.getController();
 		

--- a/src/gui/UserView.fxml
+++ b/src/gui/UserView.fxml
@@ -45,7 +45,7 @@
                   </FlowPane>
                </children>
             </GridPane>
-            <ScrollPane fx:id="myScrollPane" fitToHeight="true" prefHeight="600.0" prefWidth="1024.0" stylesheets="@menuBar.css" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+            <ScrollPane fx:id="myScrollPane" prefHeight="600.0" prefWidth="1024.0" stylesheets="@menuBar.css" GridPane.halignment="CENTER" GridPane.rowIndex="2">
             </ScrollPane>
             <FlowPane fx:id="mySubMenuBar" alignment="CENTER_LEFT" hgap="20.0" minHeight="35.0" GridPane.rowIndex="1">
                <GridPane.margin>


### PR DESCRIPTION
With the provided patch now when the screen width changes the flow pane (informationViewContainer) with move auctionTiles as needed to keep them within bounds